### PR TITLE
Prefer built-in traits for maximum flexibility

### DIFF
--- a/benches/full_text_search_lib/mod.rs
+++ b/benches/full_text_search_lib/mod.rs
@@ -59,19 +59,19 @@ pub fn regex_search<S: AsRef<str>, P: AsRef<str>>(text: S, pattern: P) -> Vec<us
     result
 }
 
-pub fn bmb_search<TT: BMByteSearchable, TP: BMByteSearchable>(text: TT, pattern: TP) -> Vec<usize> {
+pub fn bmb_search<TT: AsRef<[u8]>, TP: AsRef<[u8]>>(text: TT, pattern: TP) -> Vec<usize> {
     let bad_char_shift_map = BMByteBadCharShiftMap::create_bad_char_shift_map(&pattern).unwrap();
 
-    boyer_moore_magiclen::byte::find_full(text, pattern, &bad_char_shift_map, 0)
+    boyer_moore_magiclen::byte::find_full(text.as_ref(), pattern.as_ref(), &bad_char_shift_map, 0)
 }
 
 #[cfg(feature = "character")]
-pub fn character_search_char<TT: BMCharacterSearchable, TP: BMCharacterSearchable>(
+pub fn character_search_char<TT: AsRef<[char]>, TP: AsRef<[char]>>(
     text: TT,
     pattern: TP,
 ) -> Vec<usize> {
     let bad_char_shift_map =
         BMCharacterBadCharShiftMap::create_bad_char_shift_map(&pattern).unwrap();
 
-    boyer_moore_magiclen::character::find_full(text, pattern, &bad_char_shift_map, 0)
+    character::find_full(text.as_ref(), pattern.as_ref(), &bad_char_shift_map, 0)
 }

--- a/benches/normal_text_search_lib/mod.rs
+++ b/benches/normal_text_search_lib/mod.rs
@@ -55,19 +55,19 @@ pub fn regex_search<S: AsRef<str>, P: AsRef<str>>(text: S, pattern: P) -> Vec<us
     result
 }
 
-pub fn bmb_search<TT: BMByteSearchable, TP: BMByteSearchable>(text: TT, pattern: TP) -> Vec<usize> {
+pub fn bmb_search<TT: AsRef<[u8]>, TP: AsRef<[u8]>>(text: TT, pattern: TP) -> Vec<usize> {
     let bad_char_shift_map = BMByteBadCharShiftMap::create_bad_char_shift_map(&pattern).unwrap();
 
-    boyer_moore_magiclen::byte::find(text, pattern, &bad_char_shift_map, 0)
+    boyer_moore_magiclen::byte::find(text.as_ref(), pattern.as_ref(), &bad_char_shift_map, 0)
 }
 
 #[cfg(feature = "character")]
-pub fn character_search_char<TT: BMCharacterSearchable, TP: BMCharacterSearchable>(
+pub fn character_search_char<TT: AsRef<[char]>, TP: AsRef<[char]>>(
     text: TT,
     pattern: TP,
 ) -> Vec<usize> {
     let bad_char_shift_map =
         BMCharacterBadCharShiftMap::create_bad_char_shift_map(&pattern).unwrap();
 
-    boyer_moore_magiclen::character::find(text, pattern, &bad_char_shift_map, 0)
+    character::find(text.as_ref(), pattern.as_ref(), &bad_char_shift_map, 0)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,8 +72,6 @@ pub mod byte;
 /// This module helps you search character sub-sequences in any character sequence.
 pub mod character;
 
-pub use byte::{BMByte, BMByteBadCharShiftMap, BMByteBadCharShiftMapRev, BMByteSearchable};
+pub use byte::{BMByte, BMByteBadCharShiftMap, BMByteBadCharShiftMapRev};
 #[cfg(feature = "character")]
-pub use character::{
-    BMCharacter, BMCharacterBadCharShiftMap, BMCharacterBadCharShiftMapRev, BMCharacterSearchable,
-};
+pub use character::{BMCharacter, BMCharacterBadCharShiftMap, BMCharacterBadCharShiftMapRev};


### PR DESCRIPTION
I updated your code so that it uses the built-in AsRef, Index, and IntoIterator traits so the custom traits weren't needed.